### PR TITLE
fix: Update package.json main file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-form",
   "version": "7.0.3",
   "description": "A higher order component decorator for forms using Redux and React",
-  "main": "./lib/index.js",
+  "main": "./es/index.js",
   "module": "./es/index.js",
   "jsnext:main": "./es/index.js",
   "repository": {


### PR DESCRIPTION
The typescript compiler could not find the module because the main file was set to './lib/index.js'; now the main file is located in the ./es/index.js' file. This fixes the compiler error and loads the module.